### PR TITLE
PWN-3065 - update main screen after environment is changed

### DIFF
--- a/app/src/main/java/org/p2p/wallet/home/HomeModule.kt
+++ b/app/src/main/java/org/p2p/wallet/home/HomeModule.kt
@@ -11,6 +11,7 @@ import org.p2p.wallet.home.model.Token
 import org.p2p.wallet.home.repository.HomeDatabaseRepository
 import org.p2p.wallet.home.repository.HomeLocalRepository
 import org.p2p.wallet.home.ui.main.HomeContract
+import org.p2p.wallet.home.ui.main.HomeElementItemMapper
 import org.p2p.wallet.home.ui.main.HomePresenter
 import org.p2p.wallet.home.ui.select.SelectTokenContract
 import org.p2p.wallet.home.ui.select.SelectTokenPresenter
@@ -53,7 +54,18 @@ object HomeModule : InjectionModule {
         factory { HomeDatabaseRepository(get()) } bind HomeLocalRepository::class
 
         /* Cached data exists, therefore creating singleton */
-        single { HomePresenter(get(), get(), get(), get(), get(), get()) } bind HomeContract.Presenter::class
+        single {
+            HomePresenter(
+                updatesManager = get(),
+                userInteractor = get(),
+                settingsInteractor = get(),
+                usernameInteractor = get(),
+                sharedPreferences = get(),
+                environmentManager = get(),
+                tokenKeyProvider = get(),
+                homeElementItemMapper = HomeElementItemMapper()
+            )
+        } bind HomeContract.Presenter::class
         single {
             SendInteractor(
                 addressInteractor = get(),

--- a/app/src/main/java/org/p2p/wallet/home/model/VisibilityState.kt
+++ b/app/src/main/java/org/p2p/wallet/home/model/VisibilityState.kt
@@ -3,4 +3,6 @@ package org.p2p.wallet.home.model
 sealed class VisibilityState {
     object Visible : VisibilityState()
     object Hidden : VisibilityState()
+
+    fun toggle(): VisibilityState = if (this is Visible) Hidden else Visible
 }

--- a/app/src/main/java/org/p2p/wallet/home/repository/HomeDatabaseRepository.kt
+++ b/app/src/main/java/org/p2p/wallet/home/repository/HomeDatabaseRepository.kt
@@ -1,11 +1,11 @@
 package org.p2p.wallet.home.repository
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.p2p.wallet.home.db.TokenDao
 import org.p2p.wallet.home.model.Token
 import org.p2p.wallet.home.model.TokenComparator
 import org.p2p.wallet.home.model.TokenConverter
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class HomeDatabaseRepository(
     private val tokenDao: TokenDao
@@ -26,11 +26,11 @@ class HomeDatabaseRepository(
     }
 
     override fun getTokensFlow(): Flow<List<Token.Active>> =
-        tokenDao.getTokensFlow().map { entities ->
-            entities
-                .map { TokenConverter.fromDatabase(it) }
-                .sortedWith(TokenComparator())
-        }
+        tokenDao.getTokensFlow()
+            .map { entities ->
+                entities.map { TokenConverter.fromDatabase(it) }
+                    .sortedWith(TokenComparator())
+            }
 
     override suspend fun getUserTokens(): List<Token.Active> =
         tokenDao.getTokens().map { TokenConverter.fromDatabase(it) }

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomeContract.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomeContract.kt
@@ -7,11 +7,12 @@ import org.p2p.wallet.common.ui.widget.ActionButtonsView
 import org.p2p.wallet.home.model.HomeElementItem
 import org.p2p.wallet.home.model.Token
 import org.p2p.wallet.home.model.VisibilityState
+import org.p2p.wallet.home.ui.main.adapter.OnHomeItemsClickListener
 import java.math.BigDecimal
 
 interface HomeContract {
 
-    interface View : MvpView {
+    interface View : MvpView, OnHomeItemsClickListener {
         fun showTokens(tokens: List<HomeElementItem>, isZerosHidden: Boolean, state: VisibilityState)
         fun showTokensForBuy(tokens: List<Token>)
         fun showBalance(balance: BigDecimal, username: Username?)
@@ -22,10 +23,10 @@ interface HomeContract {
 
     interface Presenter : MvpPresenter<View> {
         fun onBuyClicked()
-        fun collectData()
-        fun refresh()
-        fun toggleVisibility(token: Token.Active)
-        fun toggleVisibilityState()
-        fun clearCache()
+        fun subscribeToUserTokensFlow()
+        fun refreshTokenAndPrices()
+        fun toggleTokenVisibility(token: Token.Active)
+        fun toggleTokenVisibilityState()
+        fun clearTokensCache()
     }
 }

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomeElementItemMapper.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomeElementItemMapper.kt
@@ -1,0 +1,29 @@
+package org.p2p.wallet.home.ui.main
+
+import org.p2p.wallet.home.model.HomeElementItem
+import org.p2p.wallet.home.model.Token
+import org.p2p.wallet.home.model.TokenVisibility
+import org.p2p.wallet.home.model.VisibilityState
+
+class HomeElementItemMapper {
+    fun mapToItem(
+        tokens: List<Token.Active>,
+        visibilityState: VisibilityState,
+        isZerosHidden: Boolean
+    ): List<HomeElementItem> {
+        return tokens.map { token ->
+            if (token.isSOL) return@map HomeElementItem.Shown(token)
+
+            when (token.visibility) {
+                TokenVisibility.SHOWN -> HomeElementItem.Shown(token)
+                TokenVisibility.HIDDEN -> HomeElementItem.Hidden(token, visibilityState)
+                TokenVisibility.DEFAULT ->
+                    if (isZerosHidden && token.isZero) {
+                        HomeElementItem.Hidden(token, visibilityState)
+                    } else {
+                        HomeElementItem.Shown(token)
+                    }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomeFragment.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomeFragment.kt
@@ -19,7 +19,6 @@ import org.p2p.wallet.home.analytics.BrowseAnalytics
 import org.p2p.wallet.home.model.HomeElementItem
 import org.p2p.wallet.home.model.Token
 import org.p2p.wallet.home.model.VisibilityState
-import org.p2p.wallet.home.ui.main.adapter.OnHomeItemsClickListener
 import org.p2p.wallet.home.ui.main.adapter.TokenAdapter
 import org.p2p.wallet.home.ui.select.bottomsheet.SelectTokenBottomSheet
 import org.p2p.wallet.intercom.IntercomService
@@ -30,6 +29,7 @@ import org.p2p.wallet.swap.ui.orca.OrcaSwapFragment
 import org.p2p.wallet.utils.SpanUtils
 import org.p2p.wallet.utils.getColor
 import org.p2p.wallet.utils.replaceFragment
+import org.p2p.wallet.utils.unsafeLazy
 import org.p2p.wallet.utils.viewbinding.viewBinding
 import java.math.BigDecimal
 import kotlin.math.absoluteValue
@@ -39,74 +39,82 @@ private const val KEY_REQUEST_TOKEN = "KEY_REQUEST_TOKEN"
 
 class HomeFragment :
     BaseMvpFragment<HomeContract.View, HomeContract.Presenter>(R.layout.fragment_home),
-    HomeContract.View,
-    OnHomeItemsClickListener {
+    HomeContract.View {
 
     companion object {
-        fun create() = HomeFragment()
+        fun create(): HomeFragment = HomeFragment()
     }
 
     override val presenter: HomeContract.Presenter by inject()
 
     private val binding: FragmentHomeBinding by viewBinding()
 
-    private val mainAdapter: TokenAdapter by lazy {
+    private val mainAdapter: TokenAdapter by unsafeLazy {
         TokenAdapter(this)
     }
 
     private val browseAnalytics: BrowseAnalytics by inject()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        with(binding) {
-            val commonTitle = getString(R.string.app_name)
-            val beta = getString(R.string.common_beta)
-            val color = getColor(R.color.textIconSecondary)
-            titleTextView.text = SpanUtils.highlightText("$commonTitle $beta", beta, color)
-
-            mainRecyclerView.layoutManager = LinearLayoutManager(requireContext())
-            mainRecyclerView.adapter = mainAdapter
-
-            with(actionButtonsView) {
-                onBuyItemClickListener = {
-                    presenter.onBuyClicked()
-                }
-                onReceiveItemClickListener = {
-                    replaceFragment(ReceiveSolanaFragment.create(null))
-                }
-                onSendClickListener = {
-                    replaceFragment(SendFragment.create())
-                }
-                onSwapItemClickListener = {
-                    replaceFragment(OrcaSwapFragment.create())
-                }
-            }
-
-            swipeRefreshLayout.setOnRefreshListener {
-                presenter.refresh()
-            }
-
-            appBarLayout.addOnOffsetChangedListener(
-                AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
-                    val offset = (verticalOffset.toFloat() / appBarLayout.height).absoluteValue
-                    (binding.actionButtonsView as? OnOffsetChangedListener)?.onOffsetChanged(offset)
-                }
-            )
-        }
+        binding.setupView()
 
         childFragmentManager.setFragmentResultListener(
             KEY_REQUEST_TOKEN,
-            viewLifecycleOwner
-        ) { _, result ->
-            when {
-                result.containsKey(KEY_RESULT_TOKEN) -> {
-                    val token = result.getParcelable<Token>(KEY_RESULT_TOKEN)
-                    if (token != null) replaceFragment(BuySolanaFragment.create(token))
-                }
-            }
+            viewLifecycleOwner,
+            ::onFragmentResult
+        )
+
+        presenter.subscribeToUserTokensFlow()
+    }
+
+    private fun FragmentHomeBinding.setupView() {
+        val commonTitle = getString(R.string.app_name)
+        val beta = getString(R.string.common_beta)
+        val color = getColor(R.color.textIconSecondary)
+        titleTextView.text = SpanUtils.highlightText(
+            commonText = "$commonTitle $beta",
+            highlightedText = beta,
+            color = color
+        )
+
+        mainRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        mainRecyclerView.adapter = mainAdapter
+
+        actionButtonsView.setupActionButtons()
+
+        swipeRefreshLayout.setOnRefreshListener {
+            presenter.refreshTokenAndPrices()
         }
 
-        presenter.collectData()
+        appBarLayout.addOnOffsetChangedListener(
+            AppBarLayout.OnOffsetChangedListener { _, verticalOffset ->
+                val offset = (verticalOffset.toFloat() / appBarLayout.height).absoluteValue
+                (actionButtonsView as? OnOffsetChangedListener)?.onOffsetChanged(offset)
+            }
+        )
+    }
+
+    private fun ActionButtonsView.setupActionButtons() {
+        onBuyItemClickListener = {
+            presenter.onBuyClicked()
+        }
+        onReceiveItemClickListener = {
+            replaceFragment(ReceiveSolanaFragment.create(token = null))
+        }
+        onSendClickListener = {
+            replaceFragment(SendFragment.create())
+        }
+        onSwapItemClickListener = {
+            replaceFragment(OrcaSwapFragment.create())
+        }
+    }
+
+    private fun onFragmentResult(requestKey: String, result: Bundle) {
+        result.getParcelable<Token>(KEY_RESULT_TOKEN)?.let {
+            replaceFragment(BuySolanaFragment.create(it))
+        }
     }
 
     override fun showTokens(tokens: List<HomeElementItem>, isZerosHidden: Boolean, state: VisibilityState) {
@@ -114,7 +122,12 @@ class HomeFragment :
     }
 
     override fun showTokensForBuy(tokens: List<Token>) {
-        SelectTokenBottomSheet.show(childFragmentManager, tokens, KEY_REQUEST_TOKEN, KEY_RESULT_TOKEN)
+        SelectTokenBottomSheet.show(
+            fm = childFragmentManager,
+            tokens = tokens,
+            requestKey = KEY_REQUEST_TOKEN,
+            resultKey = KEY_RESULT_TOKEN
+        )
     }
 
     override fun showBalance(balance: BigDecimal, username: Username?) {
@@ -136,16 +149,18 @@ class HomeFragment :
         binding.actionButtonsView.setItems(items)
     }
 
-    override fun showEmptyState(isEmpty: Boolean) = with(binding) {
-        emptyStateLayout.isVisible = isEmpty
-        swipeRefreshLayout.isVisible = !isEmpty
-        balanceTextView.isVisible = !isEmpty
-        balanceLabelTextView.isVisible = !isEmpty
+    override fun showEmptyState(isEmpty: Boolean) {
+        with(binding) {
+            emptyStateLayout.isVisible = isEmpty
+            swipeRefreshLayout.isVisible = !isEmpty
+            balanceTextView.isVisible = !isEmpty
+            balanceLabelTextView.isVisible = !isEmpty
+        }
     }
 
     override fun onDestroy() {
         /* We are clearing cache only if activity is destroyed */
-        presenter.clearCache()
+        presenter.clearTokensCache()
         super.onDestroy()
     }
 
@@ -163,7 +178,7 @@ class HomeFragment :
     }
 
     override fun onToggleClicked() {
-        presenter.toggleVisibilityState()
+        presenter.toggleTokenVisibilityState()
     }
 
     override fun onTokenClicked(token: Token.Active) {
@@ -171,7 +186,7 @@ class HomeFragment :
     }
 
     override fun onHideClicked(token: Token.Active) {
-        presenter.toggleVisibility(token)
+        presenter.toggleTokenVisibility(token)
     }
 
     override fun onSendClicked(token: Token.Active) {

--- a/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/home/ui/main/HomePresenter.kt
@@ -1,7 +1,6 @@
 package org.p2p.wallet.home.ui.main
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -16,6 +15,7 @@ import org.p2p.wallet.home.model.HomeElementItem
 import org.p2p.wallet.home.model.Token
 import org.p2p.wallet.home.model.TokenVisibility
 import org.p2p.wallet.home.model.VisibilityState
+import org.p2p.wallet.infrastructure.network.environment.EnvironmentManager
 import org.p2p.wallet.infrastructure.network.provider.TokenKeyProvider
 import org.p2p.wallet.intercom.IntercomService
 import org.p2p.wallet.settings.interactor.SettingsInteractor
@@ -24,9 +24,13 @@ import org.p2p.wallet.user.interactor.UserInteractor
 import org.p2p.wallet.utils.scaleShort
 import timber.log.Timber
 import java.math.BigDecimal
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 
-private const val DELAY_MS = 10000L
+private val POLLING_DELAY_MS = TimeUnit.SECONDS.toMillis(10)
 private const val BANNER_START_INDEX = 2
+private val TOKENS_VALID_FOR_BUY = setOf("SOL", "USDC")
+private const val BALANCE_CURRENCY = "USD"
 
 class HomePresenter(
     private val updatesManager: UpdatesManager,
@@ -34,93 +38,120 @@ class HomePresenter(
     private val settingsInteractor: SettingsInteractor,
     private val usernameInteractor: UsernameInteractor,
     private val sharedPreferences: SharedPreferences,
-    private val tokenKeyProvider: TokenKeyProvider
-
+    private val environmentManager: EnvironmentManager,
+    private val tokenKeyProvider: TokenKeyProvider,
+    private val homeElementItemMapper: HomeElementItemMapper
 ) : BasePresenter<HomeContract.View>(), HomeContract.Presenter {
 
-    companion object {
-        private const val BALANCE_CURRENCY = "USD"
+    private data class ViewState(
+        val tokens: List<Token.Active>,
+        val visibilityState: VisibilityState?,
+        val username: Username?
+    ) {
+        companion object {
+            val EMPTY = ViewState(tokens = emptyList(), visibilityState = null, username = null)
+        }
+
+        val actualVisibilityState: VisibilityState = when (visibilityState) {
+            is VisibilityState.Hidden, null -> VisibilityState.Hidden
+            is VisibilityState.Visible -> VisibilityState.Visible
+        }
     }
 
-    private var state: VisibilityState? = null
+    private var presenterState = ViewState.EMPTY
 
-    private val tokens = mutableListOf<Token.Active>()
-    private val tokensValidForBuy = listOf("SOL", "USDC")
-
-    private var username: Username? = null
-
-    private var collectJob: Job? = null
-
-    private val actions = mutableListOf(
-        ActionButtonsView.ActionButton(R.string.main_buy, R.drawable.ic_plus),
-        ActionButtonsView.ActionButton(R.string.main_receive, R.drawable.ic_receive_simple),
-        ActionButtonsView.ActionButton(R.string.main_send, R.drawable.ic_send_medium),
-        ActionButtonsView.ActionButton(R.string.main_swap, R.drawable.ic_swap_medium)
-    )
+    private var userTokensFlowJob: Job? = null
 
     override fun attach(view: HomeContract.View) {
         super.attach(view)
-        view.showActions(actions)
+
+        view.showActions(
+            listOf(
+                ActionButtonsView.ActionButton(R.string.main_buy, R.drawable.ic_plus),
+                ActionButtonsView.ActionButton(R.string.main_receive, R.drawable.ic_receive_simple),
+                ActionButtonsView.ActionButton(R.string.main_send, R.drawable.ic_send_medium),
+                ActionButtonsView.ActionButton(R.string.main_swap, R.drawable.ic_swap_medium)
+            )
+        )
+
         updatesManager.start()
-        loadData()
-        username = usernameInteractor.getUsername()
+
+        presenterState = presenterState.copy(username = usernameInteractor.getUsername())
+
+        if (presenterState.tokens.isEmpty()) {
+            initialLoadTokens()
+        } else {
+            startPollingForTokens()
+        }
+
         IntercomService.signIn(tokenKeyProvider.publicKey) {}
+
+        environmentManager.addEnvironmentListener(this::class) {
+            refreshTokenAndPrices()
+        }
     }
 
     override fun onBuyClicked() {
         launch {
-            val tokensForBuy = userInteractor.getTokensForBuy(tokensValidForBuy)
+            val tokensForBuy = userInteractor.getTokensForBuy(TOKENS_VALID_FOR_BUY.toList())
             view?.showTokensForBuy(tokensForBuy)
         }
     }
 
-    override fun collectData() {
-        collectJob?.cancel()
-        collectJob = launch {
-            userInteractor.getUserTokensFlow().collect { updatedTokens ->
-                when {
-                    isEmptyAccount(updatedTokens) -> {
-                        view?.showEmptyState(true)
-                    }
+    override fun subscribeToUserTokensFlow() {
+        userTokensFlowJob?.cancel()
+        userTokensFlowJob = launch {
+            userInteractor.getUserTokensFlow()
+                // emits two times when local tokens updated: with [] and actual list - strange
+                .collect { updatedTokens ->
+                    Timber.d("local tokens change arrived")
+                    presenterState = presenterState.copy(tokens = updatedTokens)
 
-                    updatedTokens.isNotEmpty() -> {
-                        view?.showEmptyState(false)
-                        tokens.clear()
-                        tokens += updatedTokens
-                        showTokens(updatedTokens.toMutableList())
+                    val isAccountEmpty = updatedTokens.run { size == 1 && first().isSOL && first().isZero }
+                    when {
+                        isAccountEmpty -> {
+                            view?.showEmptyState(isEmpty = true)
+                        }
+                        updatedTokens.isNotEmpty() -> {
+                            view?.showEmptyState(isEmpty = false)
+                            showTokensAndBalance()
+                        }
                     }
                 }
-            }
         }
     }
 
-    override fun refresh() {
-        view?.showRefreshing(true)
+    override fun refreshTokenAndPrices() {
         launch {
-            try {
-                fetchRates()
-                userInteractor.loadUserTokensAndUpdateData()
-            } catch (e: CancellationException) {
-                Timber.d("Loading tokens job cancelled")
-            } catch (e: Throwable) {
-                Timber.e(e, "Error loading user data")
-                view?.showErrorMessage(e)
-            } finally {
-                view?.showRefreshing(false)
-            }
+            view?.showRefreshing(isRefreshing = true)
+
+            runCatching { userInteractor.loadTokenPrices(BALANCE_CURRENCY) }
+                .onSuccess { Timber.d("refreshing prices is success") }
+                .onFailure { onTokenPricesLoadFailure(it) }
+                .getOrNull()
+                ?.runCatching { userInteractor.loadUserTokensAndUpdateLocal() }
+                ?.onSuccess { Timber.d("refreshing tokens is success") }
+                ?.onFailure { handleUserTokensUpdateFailure(it) }
+
+            view?.showRefreshing(isRefreshing = false)
         }
     }
 
-    private suspend fun fetchRates() {
-        try {
-            userInteractor.loadTokenPrices(BALANCE_CURRENCY)
-        } catch (e: Throwable) {
-            Timber.e(e, "Error loading token prices")
-            view?.showErrorSnackBar(e.message ?: e.localizedMessage)
+    private fun onTokenPricesLoadFailure(error: Throwable) {
+        Timber.e(error, "Error loading token prices")
+        view?.showErrorSnackBar(error.message ?: error.localizedMessage)
+    }
+
+    private fun handleUserTokensUpdateFailure(error: Throwable) {
+        if (error is CancellationException) {
+            Timber.d("Loading tokens job cancelled")
+        } else {
+            Timber.e(error, "Error loading user data")
+            view?.showErrorMessage(error)
         }
     }
 
-    override fun toggleVisibility(token: Token.Active) {
+    override fun toggleTokenVisibility(token: Token.Active) {
         launch {
             val visibility = when (token.visibility) {
                 TokenVisibility.SHOWN -> TokenVisibility.HIDDEN
@@ -136,80 +167,74 @@ class HomePresenter(
         }
     }
 
-    override fun toggleVisibilityState() {
-        state = when (state) {
-            is VisibilityState.Visible -> VisibilityState.Hidden
-            else -> VisibilityState.Visible
-        }
+    override fun toggleTokenVisibilityState() {
+        presenterState = presenterState.run { copy(visibilityState = visibilityState?.toggle()) }
 
-        showTokens(tokens)
+        showTokensAndBalance()
     }
 
-    override fun clearCache() {
-        tokens.clear()
+    override fun clearTokensCache() {
+        presenterState = presenterState.copy(tokens = emptyList())
     }
 
-    private fun showTokens(tokens: MutableList<Token.Active>) {
-        val balance = sumBalance(tokens)
-        view?.showBalance(balance, username)
+    private fun showTokensAndBalance() {
+        Timber.d("showing tokens on screen")
+        val balance = getUserBalance()
+        view?.showBalance(balance, presenterState.username)
 
         /* Mapping elements according to visibility settings */
         val isZerosHidden = settingsInteractor.isZerosHidden()
-        val actualState = when (state) {
-            is VisibilityState.Hidden, null -> VisibilityState.Hidden
-            is VisibilityState.Visible -> VisibilityState.Visible
-        }
-        val mappedTokens = mapTokens(tokens, isZerosHidden, actualState)
+        val actualState = presenterState.actualVisibilityState
+        val mappedTokens = buildList {
+            addAll(
+                homeElementItemMapper.mapToItem(
+                    tokens = presenterState.tokens,
+                    visibilityState = presenterState.actualVisibilityState,
+                    isZerosHidden = isZerosHidden
+                )
+            )
 
-        /* Adding banners to the main list */
-        val banners = getBanners()
-        if (mappedTokens.size > BANNER_START_INDEX) {
-            mappedTokens.add(BANNER_START_INDEX, HomeElementItem.Banners(banners))
-        } else {
-            mappedTokens.add(HomeElementItem.Banners(banners))
+            // Adding banners to the main list
+            val banners = getBanners()
+            if (this.size > BANNER_START_INDEX) {
+                add(BANNER_START_INDEX, HomeElementItem.Banners(banners))
+            } else {
+                add(HomeElementItem.Banners(banners))
+            }
         }
 
         view?.showTokens(mappedTokens, isZerosHidden, actualState)
     }
 
-    private fun loadData() {
-        if (tokens.isNotEmpty()) {
-            startPolling()
-            return
-        }
-
+    private fun initialLoadTokens() {
         launch {
-            try {
-                view?.showRefreshing(true)
-                /* We are waiting when tokenlist.json is being parsed and saved into the memory */
-                delay(1000L)
-                userInteractor.loadUserTokensAndUpdateData()
-                Timber.d("Successfully loaded tokens")
-            } catch (e: CancellationException) {
-                Timber.w("Cancelled tokens remote update")
-            } catch (e: Throwable) {
-                Timber.e(e, "Error loading tokens from remote")
-            } finally {
-                view?.showRefreshing(false)
-                startPolling()
-            }
+            Timber.d("initial token loading")
+            view?.showRefreshing(isRefreshing = true)
+            // We are waiting when tokenlist.json is being parsed and saved into the memory
+            delay(1000L)
+            kotlin.runCatching { userInteractor.loadUserTokensAndUpdateLocal() }
+                .onSuccess {
+                    Timber.d("Successfully initial loaded tokens")
+                }
+                .onFailure {
+                    if (it is CancellationException) {
+                        Timber.i("Cancelled initial tokens remote update")
+                    } else {
+                        Timber.e(it, "Error initial loading tokens from remote")
+                    }
+                }
+
+            view?.showRefreshing(isRefreshing = false)
+            startPollingForTokens()
         }
     }
 
-    private fun startPolling() {
+    private fun startPollingForTokens() {
         launch {
             try {
                 while (true) {
-                    delay(DELAY_MS)
-                    val isPollingEnabled = sharedPreferences.getBoolean(KEY_POLLING_ENABLED, true)
-                    if (isPollingEnabled) {
-                        userInteractor.loadUserTokensAndUpdateData()
-                        Timber.d("Successfully updated loaded tokens")
-                    } else {
-                        Timber.d("Skipping tokens auto-update")
-                    }
-
-                    view?.showRefreshing(false)
+                    delay(POLLING_DELAY_MS)
+                    loadTokensOnPolling()
                 }
             } catch (e: CancellationException) {
                 Timber.w("Cancelled tokens remote update")
@@ -219,36 +244,23 @@ class HomePresenter(
         }
     }
 
-    private fun sumBalance(tokens: List<Token.Active>): BigDecimal =
-        tokens
+    private suspend fun loadTokensOnPolling() {
+        val isPollingEnabled = sharedPreferences.getBoolean(KEY_POLLING_ENABLED, true)
+        if (isPollingEnabled) {
+            userInteractor.loadUserTokensAndUpdateLocal()
+            Timber.d("Successfully auto-updated loaded tokens")
+        } else {
+            Timber.d("Skipping tokens auto-update")
+        }
+    }
+
+    private fun getUserBalance(): BigDecimal =
+        presenterState.tokens
             .mapNotNull { it.totalInUsd }
             .fold(BigDecimal.ZERO, BigDecimal::add)
             .scaleShort()
 
-    private fun mapTokens(
-        tokens: MutableList<Token.Active>,
-        isZerosHidden: Boolean,
-        state: VisibilityState
-    ): MutableList<HomeElementItem> =
-        tokens
-            .map { token ->
-                if (token.isSOL) return@map HomeElementItem.Shown(token)
-
-                when (token.visibility) {
-                    TokenVisibility.SHOWN -> HomeElementItem.Shown(token)
-                    TokenVisibility.HIDDEN -> HomeElementItem.Hidden(token, state)
-                    TokenVisibility.DEFAULT -> if (isZerosHidden && token.isZero) {
-                        HomeElementItem.Hidden(token, state)
-                    } else {
-                        HomeElementItem.Shown(token)
-                    }
-                }
-            }
-            .toMutableList()
-
     private fun getBanners(): List<Banner> {
-        val usernameExists = username != null
-
         val usernameBanner = Banner(
             R.string.main_username_banner_option,
             R.string.main_username_banner_action,
@@ -256,6 +268,7 @@ class HomePresenter(
             R.color.backgroundBanner
         )
 
+        val usernameExists = presenterState.username != null
         val feedbackBanner = Banner(
             R.string.main_feedback_banner_option,
             R.string.main_feedback_banner_action,
@@ -270,7 +283,4 @@ class HomePresenter(
             listOf(usernameBanner, feedbackBanner)
         }
     }
-
-    private fun isEmptyAccount(updatedTokens: List<Token.Active>) =
-        updatedTokens.size == 1 && updatedTokens.first().isSOL && updatedTokens.first().isZero
 }

--- a/app/src/main/java/org/p2p/wallet/infrastructure/network/interceptor/RpcInterceptor.kt
+++ b/app/src/main/java/org/p2p/wallet/infrastructure/network/interceptor/RpcInterceptor.kt
@@ -35,7 +35,7 @@ open class RpcInterceptor(
     private var currentEnvironment = environmentManager.loadEnvironment()
 
     init {
-        environmentManager.setOnEnvironmentListener { newEnvironment ->
+        environmentManager.addEnvironmentListener(this::class) { newEnvironment ->
             currentEnvironment = newEnvironment
         }
     }


### PR DESCRIPTION
## Jira Ticket (Mandatory)

https://p2pvalidator.atlassian.net/browse/PWN-305

## Description of Work (Mandatory)

I tried to split the new "ViewState" changes and some renamings but haven't managed to do it properly. Please forgive me.
So, the main thing here is that now we have presenter's ViewState that caches the main things that Fragment needs. 
- When we launch Fragment the first time - the presenter loads tokens, update local storage and starts polling for tokens. Also, it subscribes to env changes.
- When we leave Fragment (onDestoyView), polling stops, but the presenter still lives with cached values. Env changes subscription lives on.
- When we change env, the presenter calls the `refresh` method and updates ONLY local storage with the new env.
- When we select Fragment next time (onCreateView) - it starts polling for tokens and gets new tokens from the database.


Feel free to curse and write angry comments :)