### PR TITLE
PWN-3277, PWN-3287 Network auto select on send screen

### DIFF
--- a/app/src/main/java/org/p2p/wallet/renbtc/utils/BitcoinAddressValidator.kt
+++ b/app/src/main/java/org/p2p/wallet/renbtc/utils/BitcoinAddressValidator.kt
@@ -1,0 +1,9 @@
+package org.p2p.wallet.renbtc.utils
+
+object BitcoinAddressValidator {
+    private const val REGEX =
+        "(bc|tb)(0([ac-hj-np-z02-9]{39}|[ac-hj-np-z02-9]{59})|" +
+            "1[ac-hj-np-z02-9]{8,87})|([13]|[mn2])[a-km-zA-HJ-NP-Z1-9]{25,39}"
+
+    fun isValid(address: String): Boolean = Regex(REGEX).matches(address)
+}

--- a/app/src/main/java/org/p2p/wallet/send/model/SearchResult.kt
+++ b/app/src/main/java/org/p2p/wallet/send/model/SearchResult.kt
@@ -11,7 +11,10 @@ sealed class SearchResult(
     data class Wrong(override val address: String) : SearchResult(address)
 
     @Parcelize
-    data class AddressOnly(override val address: String) : SearchResult(address)
+    data class AddressOnly(
+        override val address: String,
+        val networkType: NetworkType = NetworkType.SOLANA
+    ) : SearchResult(address)
 
     @Parcelize
     data class Full(override val address: String, val username: String) : SearchResult(address)

--- a/app/src/main/java/org/p2p/wallet/send/model/Target.kt
+++ b/app/src/main/java/org/p2p/wallet/send/model/Target.kt
@@ -1,15 +1,15 @@
 package org.p2p.wallet.send.model
 
 import kotlinx.parcelize.IgnoredOnParcel
+import org.p2p.solanaj.utils.PublicKeyValidator
+import org.p2p.wallet.renbtc.utils.BitcoinAddressValidator
 
 data class Target constructor(
     val value: String
 ) {
 
     companion object {
-        private const val ADDRESS_MIN_LENGTH = 24
         private const val USERNAME_MAX_LENGTH = 15
-
         private const val P2P_DOMAIN = ".p2p.sol"
         private const val SOL_DOMAIN = ".sol"
     }
@@ -18,7 +18,8 @@ data class Target constructor(
         EMPTY,
         INVALID,
         USERNAME,
-        ADDRESS;
+        SOL_ADDRESS,
+        BTC_ADDRESS
     }
 
     /**
@@ -43,7 +44,8 @@ data class Target constructor(
             val formatted = trimmedUsername
             return when {
                 formatted.length in 1..USERNAME_MAX_LENGTH -> Validation.USERNAME
-                formatted.length >= ADDRESS_MIN_LENGTH -> Validation.ADDRESS
+                PublicKeyValidator.isValid(formatted) -> Validation.SOL_ADDRESS
+                BitcoinAddressValidator.isValid(formatted) -> Validation.BTC_ADDRESS
                 formatted.isEmpty() -> Validation.EMPTY
                 else -> Validation.INVALID
             }

--- a/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
@@ -108,6 +108,7 @@ class SendPresenter(
         launch {
             try {
                 view?.showFullScreenLoading(true)
+                view?.showNetworkSelectionView(initialToken?.isRenBTC == true)
 
                 userTokens += userInteractor.getUserTokens()
                 val userPublicKey = tokenKeyProvider.publicKey

--- a/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
@@ -351,6 +351,7 @@ class SendPresenter(
 
     private fun handleAddressOnlyResult(result: SearchResult.AddressOnly) {
         view?.showAddressOnlyTarget(result.address)
+        view?.showNetworkDestination(result.networkType)
         checkAddress(result.address)
     }
 
@@ -636,13 +637,13 @@ class SendPresenter(
 
     private suspend fun searchByNetwork(address: String) {
         when (networkType) {
-            NetworkType.SOLANA -> searchByAddress(address)
+            NetworkType.SOLANA -> searchBySolAddress(address)
             /* No search for bitcoin network */
-            NetworkType.BITCOIN -> setTargetResult(SearchResult.AddressOnly(address))
+            NetworkType.BITCOIN -> setTargetResult(SearchResult.AddressOnly(address, NetworkType.BITCOIN))
         }
     }
 
-    private suspend fun searchByAddress(address: String) {
+    private suspend fun searchBySolAddress(address: String) {
         val validatedAddress = try {
             PublicKey(address)
         } catch (e: Throwable) {

--- a/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/send/ui/main/SendPresenter.kt
@@ -168,12 +168,22 @@ class SendPresenter(
             try {
                 view?.showSearchLoading(true)
                 val target = Target(value)
+
+                networkType = when (target.validation) {
+                    Target.Validation.SOL_ADDRESS -> NetworkType.SOLANA
+                    else -> NetworkType.BITCOIN
+                }
+
+                view?.showNetworkDestination(networkType)
+
                 when (target.validation) {
                     Target.Validation.USERNAME -> searchByUsername(target.trimmedUsername)
-                    Target.Validation.ADDRESS -> searchByNetwork(target.value)
+                    Target.Validation.BTC_ADDRESS -> searchByNetwork(target.value)
+                    Target.Validation.SOL_ADDRESS -> searchByNetwork(target.value)
                     Target.Validation.EMPTY -> view?.showIdleTarget()
                     Target.Validation.INVALID -> view?.showWrongAddressTarget(target.value)
                 }
+
                 sendAnalytics.logSendPasting()
             } catch (e: Throwable) {
                 Timber.e(e, "Error validating target: $value")

--- a/app/src/main/java/org/p2p/wallet/send/ui/search/SearchPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/send/ui/search/SearchPresenter.kt
@@ -8,6 +8,7 @@ import org.p2p.solanaj.core.PublicKey
 import org.p2p.wallet.R
 import org.p2p.wallet.common.mvp.BasePresenter
 import org.p2p.wallet.send.interactor.SearchInteractor
+import org.p2p.wallet.send.model.NetworkType
 import org.p2p.wallet.send.model.SearchResult
 import org.p2p.wallet.send.model.Target
 import timber.log.Timber
@@ -62,7 +63,8 @@ class SearchPresenter(
     private suspend fun validate(target: Target) {
         when (target.validation) {
             Target.Validation.USERNAME -> searchByUsername(target.trimmedUsername)
-            Target.Validation.ADDRESS -> searchByAddress(target.value)
+            Target.Validation.SOL_ADDRESS -> searchBySolAddress(target.value)
+            Target.Validation.BTC_ADDRESS -> showBtcAddress(target.value)
             Target.Validation.EMPTY -> showEmptyState()
             Target.Validation.INVALID -> showNotFound()
         }
@@ -85,7 +87,7 @@ class SearchPresenter(
         view?.showResult(usernames)
     }
 
-    private suspend fun searchByAddress(address: String) {
+    private suspend fun searchBySolAddress(address: String) {
         val publicKey = try {
             PublicKey(address)
         } catch (e: Throwable) {
@@ -96,6 +98,13 @@ class SearchPresenter(
         val result = searchInteractor.searchByAddress(publicKey.toBase58())
         view?.showMessage(R.string.send_account_found)
         view?.showResult(result)
+    }
+
+    private fun showBtcAddress(address: String) {
+        val searchResult = SearchResult.AddressOnly(address, NetworkType.BITCOIN)
+        val resultList = listOf(searchResult)
+        view?.showMessage(null)
+        view?.showResult(resultList)
     }
 
     private fun showEmptyState() {

--- a/solanaj/src/main/java/org/p2p/solanaj/core/PublicKey.kt
+++ b/solanaj/src/main/java/org/p2p/solanaj/core/PublicKey.kt
@@ -10,13 +10,21 @@ import java.io.ByteArrayOutputStream
 class PublicKey {
     private var publicKey: ByteArray
 
+    @Throws(IllegalArgumentException::class)
     constructor(publicKey: String) {
-        PublicKeyValidator.validate(publicKey)
+        require(PublicKeyValidator.isValid(publicKey)) {
+            "Invalid public key input[String]"
+        }
+
         this.publicKey = Base58.decode(publicKey)
     }
 
+    @Throws(IllegalArgumentException::class)
     constructor(publicKey: ByteArray) {
-        PublicKeyValidator.validate(publicKey)
+        require(PublicKeyValidator.isValid(publicKey)) {
+            "Invalid public key input[ByteArray]"
+        }
+
         this.publicKey = publicKey
     }
 

--- a/solanaj/src/main/java/org/p2p/solanaj/utils/PublicKeyValidator.kt
+++ b/solanaj/src/main/java/org/p2p/solanaj/utils/PublicKeyValidator.kt
@@ -6,17 +6,9 @@ import org.p2p.solanaj.utils.crypto.Base58Utils
 object PublicKeyValidator {
     private const val REGEX = "[1-9A-HJ-NP-Za-km-z]{32,44}"
 
-    @Throws(IllegalArgumentException::class)
-    fun validate(publicKey: String) {
-        require(Regex(REGEX).matches(publicKey) && Base58Utils.decode(publicKey).size == PublicKey.PUBLIC_KEY_LENGTH) {
-            "Invalid public key input[String]"
-        }
-    }
+    fun isValid(publicKey: String): Boolean =
+        Regex(REGEX).matches(publicKey) && Base58Utils.decode(publicKey).size == PublicKey.PUBLIC_KEY_LENGTH
 
-    @Throws(IllegalArgumentException::class)
-    fun validate(publicKey: ByteArray) {
-        require(Regex(REGEX).matches(Base58Utils.encode(publicKey)) && publicKey.size == PublicKey.PUBLIC_KEY_LENGTH) {
-            "Invalid public key input[ByteArray]"
-        }
-    }
+    fun isValid(publicKey: ByteArray): Boolean =
+        Regex(REGEX).matches(Base58Utils.encode(publicKey)) && publicKey.size == PublicKey.PUBLIC_KEY_LENGTH
 }


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-3277
https://p2pvalidator.atlassian.net/browse/PWN-3287

## Description of Work

- Automatically select Solana or Bitcoin network by receiver address when sending renBTC
- Fix network selection view visibility on opening send screen from renBTC

## Screenshots

<img width="526" alt="Screenshot 2022-04-24 at 20 04 59" src="https://user-images.githubusercontent.com/100695872/164991520-cbfccbe1-4f1f-4403-9db2-0c3dbb72955c.png">
