### PR TITLE
PWN-3753 - Fix API keys filling for develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,12 @@ commands:
           name: "Create apikey.properties and fill them"
           command: |
             touch apikey.properties
-            echo 'rpcPoolApiKey="${RPC_POOL_API_KEY}"' >> apikey.properties
-            echo 'moonpayKey="${MOONPAY_KEY}"' >> apikey.properties
-            echo 'comparePublicKey="${COMPARE_PUBLIC_KEY}"' >> apikey.properties
-            echo 'intercomApiKey="${INTERCOM_API_KEY}"' >> apikey.properties
-            echo 'intercomAppId="${INTERCOM_APP_ID}"' >> apikey.properties
-            echo 'amplitudeKey="${AMPLITUDE_KEY}"' >> apikey.properties
+            echo "rpcPoolApiKey=\"${RPC_POOL_API_KEY}\"" >> apikey.properties
+            echo "moonpayKey=\"${MOONPAY_KEY}\"" >> apikey.properties
+            echo "comparePublicKey=\"${COMPARE_PUBLIC_KEY}\"" >> apikey.properties
+            echo "intercomApiKey=\"${INTERCOM_API_KEY}\"" >> apikey.properties
+            echo "intercomAppId=\"${INTERCOM_APP_ID}\"" >> apikey.properties
+            echo "amplitudeKey=\"${AMPLITUDE_KEY}\"" >> apikey.properties
             echo "apikey.properties created succesfully"
 
   restore_gradle_cache:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,8 @@ String getVersionBuild() {
 }
 
 String getBuildAppFileName() {
-    """p2p_wallet_${getVersionBuild()}_${VERSION_NAME}_${taskNumber()}"""
+    def taskNumberWithoutSlash = taskNumber().replace("/", "-")
+    "p2p_wallet_${getVersionBuild()}_${VERSION_NAME}_${taskNumberWithoutSlash}"
 }
 
 android {


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-3753

## Description of Work

So CI couldn't find AAB to upload because taskNumber returns the string with the '/' that creates new folder instead of using it in the name.
before
`p2p_wallet_106000}_1.6.0_release/`

`1.6.0.aab`
after
`p2p_wallet_106000}_1.6.0_release-1.6.0.aab`