### PR TITLE
PWN-3595 - save images with timestamp to make not override latest images of QRCodes

### DIFF
--- a/app/src/main/java/org/p2p/wallet/auth/repository/FileRepository.kt
+++ b/app/src/main/java/org/p2p/wallet/auth/repository/FileRepository.kt
@@ -82,8 +82,8 @@ class FileRepository(
     private fun ensurePdfFolderExists() = pdfFolder.mkdirs()
     private fun ensureMiscFolderExists() = miscFolder.mkdirs()
 
-    fun saveBitmapAsFile(bitmap: Bitmap, name: String? = null, toPublic: Boolean = false): File? {
-        val fileName = name ?: Date().toString()
+    fun saveBitmapAsFile(bitmap: Bitmap, name: String, toPublic: Boolean = false): File? {
+        val fileName = "$name${Date().time}"
         val appName = context.getString(R.string.app_name)
         val mimeType = "image/png"
         try {

--- a/app/src/main/java/org/p2p/wallet/auth/ui/security/SecurityKeyPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/auth/ui/security/SecurityKeyPresenter.kt
@@ -9,7 +9,7 @@ import org.p2p.wallet.common.mvp.BasePresenter
 import org.p2p.wallet.restore.interactor.SecretKeyInteractor
 import kotlin.properties.Delegates
 
-private const val SECURE_KEY_NAME = "SecureKey"
+private const val SECURITY_KEY_IMAGE_NAME = "SecureKey"
 
 class SecurityKeyPresenter(
     private val context: Context,
@@ -66,7 +66,7 @@ class SecurityKeyPresenter(
 
     override fun createScreenShootFile(bitmap: Bitmap) {
         try {
-            val file = fileRepository.saveBitmapAsFile(bitmap, SECURE_KEY_NAME) ?: return
+            val file = fileRepository.saveBitmapAsFile(bitmap, SECURITY_KEY_IMAGE_NAME) ?: return
             view?.shareScreenShot(file)
         } catch (e: Exception) {
             view?.showErrorMessage(e)

--- a/app/src/main/java/org/p2p/wallet/auth/ui/security/SecurityKeyPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/auth/ui/security/SecurityKeyPresenter.kt
@@ -9,6 +9,8 @@ import org.p2p.wallet.common.mvp.BasePresenter
 import org.p2p.wallet.restore.interactor.SecretKeyInteractor
 import kotlin.properties.Delegates
 
+private const val SECURE_KEY_NAME = "SecureKey"
+
 class SecurityKeyPresenter(
     private val context: Context,
     private val secretKeyInteractor: SecretKeyInteractor,
@@ -64,7 +66,7 @@ class SecurityKeyPresenter(
 
     override fun createScreenShootFile(bitmap: Bitmap) {
         try {
-            val file = fileRepository.saveBitmapAsFile(bitmap) ?: return
+            val file = fileRepository.saveBitmapAsFile(bitmap, SECURE_KEY_NAME) ?: return
             view?.shareScreenShot(file)
         } catch (e: Exception) {
             view?.showErrorMessage(e)


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-3595

## Description of Work

Save images with timestamp to make not override latest images of QRCodes

