### PR TITLE
PWN-3873 - display the button "X" on the pin-code screen even though nothing is entered

### DIFF
--- a/app/src/main/java/org/p2p/wallet/common/ui/widget/PinView.kt
+++ b/app/src/main/java/org/p2p/wallet/common/ui/widget/PinView.kt
@@ -134,6 +134,5 @@ class PinView @JvmOverloads constructor(
 
     private fun updateDots() {
         binding.pinCodeView.refresh(pinCode.length)
-        binding.keyboardView.setRightButtonVisible(pinCode.isNotEmpty())
     }
 }

--- a/app/src/main/res/layout/widget_keyboard.xml
+++ b/app/src/main/res/layout/widget_keyboard.xml
@@ -130,8 +130,8 @@
             android:id="@+id/additionalRightPinCodeButton"
             android:layout_width="62dp"
             android:layout_height="62dp"
-            android:visibility="invisible"
             app:keyboard_button_image="@drawable/ic_backspace" />
+
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-3873

## Description of Work

Display the button "X" on the pin-code screen even though nothing is entered

## Screenshots 
![Android Emulator - Pixel_5_API_30:5556 2022-06-17 11-47-56](https://user-images.githubusercontent.com/99185280/174266065-5ab6277b-e634-4f4b-bb4f-38dd6c84cedd.png)

