### PR TITLE
PWN-4567 - fix crash when user logouts due to dependency graph recreation

### DIFF
--- a/app/src/main/java/org/p2p/wallet/App.kt
+++ b/app/src/main/java/org/p2p/wallet/App.kt
@@ -9,6 +9,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.core.logger.Level
 import org.p2p.solanaj.utils.SolanjLogger
 import org.p2p.wallet.auth.AuthModule
@@ -24,6 +25,7 @@ import org.p2p.wallet.history.HistoryStrategyModule
 import org.p2p.wallet.home.HomeModule
 import org.p2p.wallet.infrastructure.InfrastructureModule
 import org.p2p.wallet.infrastructure.network.NetworkModule
+import org.p2p.wallet.infrastructure.transactionmanager.TransactionManagerModule
 import org.p2p.wallet.intercom.IntercomService
 import org.p2p.wallet.notification.AppNotificationManager
 import org.p2p.wallet.push_notifications.PushNotificationsModule
@@ -43,8 +45,6 @@ import org.p2p.wallet.user.repository.prices.di.TokenPricesModule
 import org.p2p.wallet.utils.SolanajTimberLogger
 import timber.log.Timber
 import kotlinx.coroutines.launch
-import org.koin.androidx.workmanager.koin.workManagerFactory
-import org.p2p.wallet.infrastructure.transactionmanager.TransactionManagerModule
 
 class App : Application() {
 
@@ -81,7 +81,10 @@ class App : Application() {
             // FIXME
             androidLogger(level = Level.ERROR)
             androidContext(this@App)
-            workManagerFactory()
+            // uncomment in PWN-4197
+            // workManagerFactory inside calls WorkManager.initialize that causes IllegalStateException
+            // reason: WorkManager.initialize should be called ONLY ONCE but called twice when user logouts
+            // workManagerFactory()
             modules(
                 listOf(
                     // core modules


### PR DESCRIPTION
## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-4567

## Description of Work

workManagerFactory inside calls WorkManager.initialize that causes IllegalStateException
reason: WorkManager.initialize should be called ONLY ONCE but called twice when user logouts