### PR TITLE
PWN-6412 - Fraction input fixes

### DIFF
--- a/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendContract.kt
+++ b/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendContract.kt
@@ -19,6 +19,7 @@ interface NewSendContract {
         fun showAccountCreationFeeInfo(tokenSymbol: String, amountInUsd: String, hasAlternativeToken: Boolean)
         fun showProgressDialog(internalTransactionId: String, data: NewShowProgress)
         fun showTokenSelection(tokens: List<Token.Active>, selectedToken: Token.Active?)
+        fun showDebugInfo(text: CharSequence)
 
         fun setBottomButtonText(text: TextContainer?)
         fun setSliderText(text: String?)

--- a/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendFragment.kt
+++ b/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendFragment.kt
@@ -201,6 +201,10 @@ class NewSendFragment :
         binding.widgetSendDetails.setInputTextColor(colorRes)
     }
 
+    override fun showDebugInfo(text: CharSequence) {
+        binding.textViewDebug.text = text
+    }
+
     override fun showTokenSelection(tokens: List<Token.Active>, selectedToken: Token.Active?) {
         addFragment(
             target = NewSelectTokenFragment.create(

--- a/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendPresenter.kt
+++ b/app/src/main/java/org/p2p/wallet/newsend/ui/NewSendPresenter.kt
@@ -5,6 +5,7 @@ import org.p2p.core.common.TextContainer
 import org.p2p.core.token.Token
 import org.p2p.core.utils.asNegativeUsdTransaction
 import org.p2p.core.utils.emptyString
+import org.p2p.wallet.BuildConfig
 import org.p2p.wallet.R
 import org.p2p.wallet.common.di.AppScope
 import org.p2p.wallet.common.mvp.BasePresenter
@@ -147,8 +148,10 @@ class NewSendPresenter(
 
         val feesLabel = total.getFeesInToken(inputAmount.isEmpty()).format(resources)
         view.setFeeLabel(feesLabel)
-
         updateButton(sourceToken, feeRelayerState)
+
+        // FIXME: only for debug needs, remove after release
+        if (BuildConfig.DEBUG) buildDebugInfo(feeRelayerState.solanaFee)
     }
 
     private fun handleFeeRelayerStateUpdate(
@@ -410,6 +413,13 @@ class NewSendPresenter(
                 view?.setBottomButtonText(null)
                 view?.setInputColor(state.totalAmountTextColor)
             }
+        }
+    }
+
+    private fun buildDebugInfo(solanaFee: SendSolanaFee?) {
+        launch {
+            val debugInfo = feeRelayerManager.buildDebugInfo(solanaFee)
+            view?.showDebugInfo(debugInfo)
         }
     }
 

--- a/app/src/main/res/layout/fragment_send_new.xml
+++ b/app/src/main/res/layout/fragment_send_new.xml
@@ -68,7 +68,7 @@
         android:layout_marginTop="16dp"
         android:gravity="end"
         android:paddingHorizontal="16dp"
-        android:textAppearance="@style/UiKit.TextAppearance.SemiBold.Text3"
+        android:textAppearance="@style/UiKit.TextAppearance.SemiBold.Label2"
         app:layout_constraintTop_toBottomOf="@id/widgetSendDetails"
         tools:text="Balance account" />
 


### PR DESCRIPTION
PWN-6405 - Fee payer change screen showing logic fixed 
PWN-6389 - Disabled token change if send is launched from token details 
NO-TICKET - Added debug info from fee relayer

## Jira Ticket

https://p2pvalidator.atlassian.net/browse/PWN-6412
https://p2pvalidator.atlassian.net/browse/PWN-6405
https://p2pvalidator.atlassian.net/browse/PWN-6389
https://p2pvalidator.atlassian.net/browse/PWN-6437

## Description of Work

PWN-6412 - Fraction input fixes
PWN-6405 - Fee payer change screen showing logic fixed
PWN-6389 - Disabled token change if send is launched from token details
PWN-6437 - Token comparator updated. Now we have this priority: USDC -> USDT -> Total lamports. (No SOL priority rn) 
NO-TICKET - Added debug info from fee relayer
NO-TICKET - Moved initial data loading to splash screen and other fixes

## Screenshots (Optional)

Screenshot #1 | Screenshot #2 | Screenshot #3
:------------:|:-------------:|:------------:
[Paste Pic 1] | [Paste Pic 2] | [Paste Pic 3]
